### PR TITLE
Fix bug while constructing TraditionalKeySignature

### DIFF
--- a/pymusicxml/score_components.py
+++ b/pymusicxml/score_components.py
@@ -1523,7 +1523,7 @@ class KeySignature(MusicXMLComponent):
         if isinstance(interpretable_as_key_signature, KeySignature):
             return interpretable_as_key_signature
         elif isinstance(interpretable_as_key_signature, int):
-            return TraditionalKeySignature(int)
+            return TraditionalKeySignature(interpretable_as_key_signature)
         elif isinstance(interpretable_as_key_signature, str):
             interpretable_as_key_signature = interpretable_as_key_signature.lower().replace("-", "").\
                 replace("sharp", "s").replace("flat", "f")


### PR DESCRIPTION
<img width="231" alt="1692618232412" src="https://github.com/MarcTheSpark/pymusicxml/assets/12388774/ce2c0735-b9cd-4526-aecf-65636f161114">
The value of attributes.key.fifths is incorrect because of the bug.